### PR TITLE
Add dev container for cloud-resume development

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -35,9 +35,6 @@
       }
     }
   },
-  "mounts": [
-    "source=${localEnv:HOME}${localEnv:USERPROFILE}/.aws,target=/home/vscode/.aws,type=bind,consistency=cached"
-  ],
   "forwardPorts": [5173],
   "portsAttributes": {
     "5173": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,50 @@
+{
+  "name": "Cloud Resume",
+  "image": "mcr.microsoft.com/devcontainers/base:bookworm",
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "installZsh": true,
+      "username": "vscode",
+      "upgradePackages": true
+    },
+    "ghcr.io/devcontainers/features/node:2": {
+      "version": "lts",
+      "nodeGypDependencies": true
+    },
+    "ghcr.io/devcontainers/features/git:1": {
+      "version": "latest"
+    },
+    "ghcr.io/devcontainers/features/aws-cli:1": {
+      "version": "latest"
+    },
+    "ghcr.io/devcontainers-extra/features/aws-cdk:2": {
+      "version": "latest"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "svelte.svelte-vscode",
+        "AmazonWebServices.aws-toolkit-vscode"
+      ],
+      "settings": {
+        "editor.formatOnSave": true,
+        "svelte.enable-ts-plugin": true
+      }
+    }
+  },
+  "mounts": [
+    "source=${localEnv:HOME}${localEnv:USERPROFILE}/.aws,target=/home/vscode/.aws,type=bind,consistency=cached"
+  ],
+  "forwardPorts": [5173],
+  "portsAttributes": {
+    "5173": {
+      "label": "Svelte/Vite Dev Server",
+      "onAutoForward": "notify"
+    }
+  },
+  "postCreateCommand": "bash -lc 'npm install -g @fission-ai/openspec@latest'",
+  "remoteUser": "vscode"
+}


### PR DESCRIPTION
## Summary
- Adds a VS Code/Cursor dev container with Node LTS, AWS CLI, AWS CDK, Svelte tooling, and OpenSpec
- Mounts host `~/.aws` credentials for AWS CLI/CDK usage
- Forwards port 5173 for Svelte/Vite development

## Test plan
- [ ] Reopen project in Dev Container and confirm build completes
- [ ] Verify `node --version`, `aws --version`, `cdk --version`, and `openspec --version`
- [ ] Confirm Svelte VS Code extension is installed
- [ ] Confirm AWS credentials are available when `~/.aws` exists on host

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Developer-environment-only change; no application or deployment runtime behavior is modified.
> 
> **Overview**
> Introduces a **VS Code/Cursor dev container** so contributors can work in a consistent **Debian Bookworm** environment without manual local setup.
> 
> The image layers in **Node LTS** (with native build deps), **Git**, **AWS CLI**, and **AWS CDK**, and runs a **post-create** global install of **OpenSpec**. Editor defaults add **ESLint**, **Prettier**, **Svelte**, and **AWS Toolkit**, with format-on-save and the Svelte TS plugin enabled.
> 
> **Host `~/.aws`** is bind-mounted into the container for CLI/CDK auth, and **port 5173** is forwarded for the **Svelte/Vite** dev server.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d3de2cf9eec0e44e7e6ebbc1e7ffbb288307539. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->