### PR TITLE
Use pnpm exec for CDK app entry

### DIFF
--- a/iac/cdk.json
+++ b/iac/cdk.json
@@ -1,5 +1,5 @@
 {
-  "app": "npx tsx bin/cloud-resume.ts",
+  "app": "pnpm exec tsx bin/cloud-resume.ts",
   "watch": {
     "include": ["**"],
     "exclude": [


### PR DESCRIPTION
## Summary
- Switch `iac/cdk.json` app entry from `npx tsx` to `pnpm exec tsx` for pnpm consistency

## Test plan
- [ ] `pnpm --filter @cloud-resume/iac synth` runs without npm warnings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single config string change with no runtime or infrastructure logic impact.
> 
> **Overview**
> Updates the CDK **`app`** command in `iac/cdk.json` from **`npx tsx bin/cloud-resume.ts`** to **`pnpm exec tsx bin/cloud-resume.ts`** so synth/deploy runs through the repo’s pnpm toolchain instead of npx.
> 
> This aligns CDK with the monorepo’s package manager and should avoid npm-related warnings when running commands like `pnpm --filter @cloud-resume/iac synth`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e616faf3c4e04b5ec0c1d4319047a2eb7744dfae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->