### PR TITLE
Set up development environment + add AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is the **Cloud Resume** pnpm monorepo (Node >= 20, pnpm 11.7.0). Dependencies are
+installed automatically by the startup update script (`corepack enable` + `pnpm install`),
+so you normally do not need to install anything manually.
+
+### Services
+
+| Service | Dir | Dev command | Port | Notes |
+|---------|-----|-------------|------|-------|
+| Frontend (static résumé site) | `frontend/` | `pnpm dev:frontend` | 8080 | The product; renders the résumé client-side from `frontend/js/resume-data.js`. Does NOT call the API. |
+| API (Express health stub) | `api/` | `pnpm dev:api` | 3000 | Only exposes `GET /health` → `{"status":"ok"}`. Scaffold for future dynamic features. |
+
+Build-only packages (not long-running services): `packages/shared-types` (shared TS types,
+`tsc`) and `iac` (AWS CDK deploy tooling). Standard commands live in `README.md` and the
+root `package.json` scripts.
+
+### Non-obvious caveats
+
+- **pnpm is mandatory.** `npm`/`yarn` are blocked by an `only-allow pnpm` preinstall hook and
+  `engine-strict` in `.npmrc`. Always use pnpm.
+- `pnpm typecheck` builds `@cloud-resume/shared-types` first (the API imports its compiled
+  output), so run it (or build shared-types) before typechecking the API in isolation.
+- `pnpm lint` is currently a stub (`echo "Lint not configured yet"`) — it is a no-op, not a
+  real linter.
+- No database, no `.env`, and no secrets are required to run anything locally.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Set up and verified the local development environment for the **Cloud Resume** pnpm monorepo, and added `AGENTS.md` documenting Cursor Cloud setup/run notes.

- Installed dependencies with `pnpm install` (Node 22, pnpm 11.7.0).
- Verified `pnpm typecheck` and `pnpm build` pass (`lint` is a documented no-op stub).
- Ran the frontend (`pnpm dev:frontend`, :8080) and API (`pnpm dev:api`, :3000) dev servers.
- Completed a hello-world: loaded the résumé site in the browser (renders client-side) and confirmed the API `/health` returns `{"status":"ok"}`.

## Walkthrough

[cloud_resume_frontend_and_api_demo.mp4](https://cursor.com/agents/bc-fdcc03a0-ce6d-4cc7-8df0-1c3087e33955/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcloud_resume_frontend_and_api_demo.mp4)

Résumé site rendering and API health response:

[Résumé page top](https://cursor.com/agents/bc-fdcc03a0-ce6d-4cc7-8df0-1c3087e33955/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fresume_page_top.webp)
[API /health JSON](https://cursor.com/agents/bc-fdcc03a0-ce6d-4cc7-8df0-1c3087e33955/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapi_health_response.webp)

## Notes

- Update script (runs on VM startup): `corepack enable` then `pnpm install`.
- `AGENTS.md` captures durable, non-obvious caveats (pnpm-only enforcement, `typecheck` builds `shared-types` first, `lint` is a stub, no DB/secrets needed).


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fdcc03a0-ce6d-4cc7-8df0-1c3087e33955"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fdcc03a0-ce6d-4cc7-8df0-1c3087e33955"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

